### PR TITLE
feat: 인메모리 To-Do API 서버 구현

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/yjh107/todo/config/ApiDocumentationConfig.java
+++ b/src/main/java/com/yjh107/todo/config/ApiDocumentationConfig.java
@@ -1,4 +1,20 @@
 package com.yjh107.todo.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class ApiDocumentationConfig {
+
+    @Bean
+    public OpenAPI apiDocumentation() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("TODO List API")
+                                .version("1.0")
+                                .description("Spring Boot3를 이용한 TODO List API 문서"));
+    }
 }

--- a/src/main/java/com/yjh107/todo/controller/TodoController.java
+++ b/src/main/java/com/yjh107/todo/controller/TodoController.java
@@ -29,7 +29,7 @@ public class TodoController {
         List<Todo> todos = todoService.findAll();
 
         if (todos == null || todos.isEmpty()) {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.noContent().build();
         }
 
         return ResponseEntity.ok(todos);

--- a/src/main/java/com/yjh107/todo/controller/TodoController.java
+++ b/src/main/java/com/yjh107/todo/controller/TodoController.java
@@ -1,4 +1,99 @@
 package com.yjh107.todo.controller;
 
+import com.yjh107.todo.model.Todo;
+import com.yjh107.todo.service.TodoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/todos/v1")
 public class TodoController {
+
+    @Autowired
+    private TodoService todoService;
+
+    // getAllTodos(): 모든 Todo 항목 조회 API
+    @GetMapping
+    @Operation(summary = "전체 작업 조회", description = "전체 작업 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "204", description = "내용 없음")
+    })
+    public ResponseEntity<List<Todo>> getAllTodos() {
+        List<Todo> todos = todoService.findAll();
+
+        if (todos == null || todos.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(todos);
+    }
+
+    // getTodoById(): 특정 ID의 Todo 항목 조회
+    @GetMapping("/{id}")
+    @Operation(summary = "작업 조회", description = "ID로 작업 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "작업 없음")
+    })
+    public ResponseEntity<Todo> getTodoById(@PathVariable Long id) {
+        Todo todo = todoService.findById(id);
+
+        if (todo == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(todo);
+    }
+
+    // createTodo(): Todo 항목 생성
+    @PostMapping
+    @Operation(summary = "작업 생성", description = "새로운 작업 생성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성됨")
+    })
+    public ResponseEntity<Todo> createTodo(@RequestBody Todo todo) {
+        return ResponseEntity.status(201).body(todoService.save(todo));
+    }
+
+    // updateTodo: 기존 Todo 항목 수정
+    @PutMapping("/{id}")
+    @Operation(summary = "작업 수정", description = "ID로 작업 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "작업 없음")
+    })
+    public ResponseEntity<Todo> updateTodo(@PathVariable Long id,
+                                           @RequestBody Todo todo) {
+        Todo existingTodo = todoService.findById(id);
+        if (existingTodo == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(todoService.update(id, todo));
+    }
+
+    // deleteTodo(): 특정 ID의 Todo 항목 삭제
+    @DeleteMapping("/{id}")
+    @Operation(summary = "작업 삭제", description = "ID로 작업 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "내용 없음"),
+            @ApiResponse(responseCode = "404", description = "작업 없음")
+    })
+    public ResponseEntity<Void> deleteTodo(@PathVariable Long id) {
+        Todo todo = todoService.findById(id);
+
+        if (todo == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        todoService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/yjh107/todo/model/Todo.java
+++ b/src/main/java/com/yjh107/todo/model/Todo.java
@@ -1,4 +1,18 @@
 package com.yjh107.todo.model;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Data   // 클래스에 대한 Getter, Setter, toString, equals, hashCode 메서드 자동 생성
+@NoArgsConstructor  // 매개변수가 없는 기본 생성자 자동 생성
+@AllArgsConstructor // 모든 필드를 매개변수로 받는 생성자 자동 생성
 public class Todo {
+
+    private Long id;
+    @NonNull    // 수식하는 필드에 null을 할당하려는 시도에 대해 NullPointerException 발생
+    private String title;
+    private String description;
+    private boolean completed;
 }

--- a/src/main/java/com/yjh107/todo/repository/TodoInMemoryRepository.java
+++ b/src/main/java/com/yjh107/todo/repository/TodoInMemoryRepository.java
@@ -1,4 +1,44 @@
 package com.yjh107.todo.repository;
 
+import com.yjh107.todo.model.Todo;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Todo 항목을 저장, 조회, 수정, 삭제하는 CRUD(Create, Read, Update, Delete)
+ * AtomicLong을 사용하여 Todo 항목의 고유 ID를 자동으로 생성
+ * Repository  애너테이션은 자동으로 해당 클래스를 리포지토리 빈으로 관리하도록 하여
+ * 다른 빈(예: 서비스 빈)이 이 리포지토리 빈을 사용할 수 있도록 만듭니다.
+ */
+@Repository
 public class TodoInMemoryRepository {
+
+    private final Map<Long, Todo> todoMap = new HashMap<>();
+    private final AtomicLong counter = new AtomicLong();
+
+    public List<Todo> findAll() {
+        return new ArrayList<>(todoMap.values());
+    }
+
+    public Todo findById(Long id) {
+        return todoMap.get(id);
+    }
+
+    public Todo save(Todo todo) {
+        if (todo.getId() == null) {
+            todo.setId(counter.incrementAndGet());
+        }
+
+        todoMap.put(todo.getId(), todo);
+        return todo;
+    }
+
+    public void deleteById(Long id) {
+        todoMap.remove(id);
+    }
 }

--- a/src/main/java/com/yjh107/todo/service/TodoService.java
+++ b/src/main/java/com/yjh107/todo/service/TodoService.java
@@ -1,4 +1,40 @@
 package com.yjh107.todo.service;
 
+import com.yjh107.todo.model.Todo;
+import com.yjh107.todo.repository.TodoInMemoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
 public class TodoService {
+
+    private final TodoInMemoryRepository todoRepository;
+
+    @Autowired
+    public TodoService(TodoInMemoryRepository todoRepository) {
+        this.todoRepository = todoRepository;
+    }
+
+    public List<Todo> findAll() {
+        return todoRepository.findAll();
+    }
+
+    public Todo findById(Long id) {
+        return todoRepository.findById(id);
+    }
+
+    public Todo save(Todo todo) {
+        return todoRepository.save(todo);
+    }
+
+    public Todo update(Long id, Todo todo) {
+        todo.setId(id);
+        return todoRepository.save(todo);
+    }
+
+    public void delete(Long id) {
+        todoRepository.deleteById(id);
+    }
 }

--- a/src/test/java/com/yjh107/todo/controller/TodoControllerTests.java
+++ b/src/test/java/com/yjh107/todo/controller/TodoControllerTests.java
@@ -1,4 +1,118 @@
 package com.yjh107.todo.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.yjh107.todo.model.Todo;
+import com.yjh107.todo.service.TodoService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(TodoController.class)
 public class TodoControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TodoService todoService;
+
+    @Test
+    public void testGetTodoById() throws Exception {
+        Todo todo = new Todo();
+        todo.setId(1L);
+        todo.setTitle("Test Todo");
+
+        given(todoService.findById(1L)).willReturn(todo);
+
+        mockMvc.perform(get("/api/todos/v1/1")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("Test Todo"));
+    }
+
+    @Test
+    public void testGetAllTodos() throws Exception {
+        given(todoService.findAll()).willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/todos/v1")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        given(todoService.findAll())
+                .willReturn(
+                    Collections.singletonList(
+                            new Todo(1L, "Test Todo", "Description", false)));
+
+        mockMvc.perform(get("/api/todos/v1")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1L))
+                .andExpect(jsonPath("$[0].title").value("Test Todo"));
+    }
+
+    @Test
+    public void testCreateTodo() throws Exception {
+        Todo todo = new Todo();
+        todo.setId(1L);
+        todo.setTitle("New Todo");
+
+        given(todoService.save(any(Todo.class))).willReturn(todo);
+
+        mockMvc.perform(
+                post("/api/todos/v1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"New Todo\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("New Todo"));
+    }
+
+    @Test
+    public void testUpdateTodo() throws Exception {
+        Todo exisitingTodo = new Todo();
+        exisitingTodo.setId(1L);
+        exisitingTodo.setTitle("Existing Todo");
+
+        Todo updatedTodo = new Todo();
+        updatedTodo.setId(1L);
+        updatedTodo.setTitle("Updated Todo");
+
+        given(todoService.findById(1L)).willReturn(exisitingTodo);
+        given(todoService.update(anyLong(), any(Todo.class))).willReturn(updatedTodo);
+
+        mockMvc.perform(
+                put("/api/todos/v1/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"title\": \"Updated Todo\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.title").value("Updated Todo"));
+    }
+
+    @Test
+    public void testDeleteTodo() throws Exception {
+        Todo todo = new Todo();
+        todo.setId(1L);
+        todo.setTitle("Test Todo");
+
+        given(todoService.findById(1L)).willReturn(todo);
+
+        mockMvc.perform(
+                delete("/api/todos/v1/1").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+    }
 }

--- a/src/test/java/com/yjh107/todo/service/TodoServiceTests.java
+++ b/src/test/java/com/yjh107/todo/service/TodoServiceTests.java
@@ -1,4 +1,66 @@
 package com.yjh107.todo.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.yjh107.todo.model.Todo;
+import com.yjh107.todo.repository.TodoInMemoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
 public class TodoServiceTests {
+
+    @Autowired private TodoService todoService;
+
+    @BeforeEach
+    void setUp() {
+        todoService = new TodoService(new TodoInMemoryRepository());
+        todoService.save(new Todo(null, "Test Todo 1", "Description 1", false));
+        todoService.save(new Todo(null, "Test Todo 2", "Description 2", true));
+    }
+
+    @Test
+    void testFindAll() {
+        List<Todo> todos = todoService.findAll();
+
+        assertThat(todos).hasSize(2);
+    }
+
+    @Test
+    void testSaveTodo() {
+        Todo todo = new Todo(null, "New Todo", "New Description", false);
+        todoService.save(todo);
+
+        assertThat(todoService.findAll()).hasSize(3);
+    }
+
+    @Test
+    void testFindById() {
+        Todo todo = todoService.findById(1L);
+
+        assertThat(todo).isNotNull();
+        assertThat(todo.getTitle()).isEqualTo("Test Todo 1");
+    }
+
+    @Test
+    void testUpdateTodo() {
+        Todo updatedTodo = new Todo(1L, "Updated Todo", "Updated Description", true);
+        todoService.update(1L, updatedTodo);
+        Todo todo = todoService.findById(1L);
+
+        assertThat(todo.getTitle()).isEqualTo("Updated Todo");
+        assertThat(todo.getDescription()).isEqualTo("Updated Description");
+        assertThat(todo.isCompleted()).isTrue();
+    }
+
+    @Test
+    void testDeleteTodo() {
+        todoService.delete(1L);
+        assertThat(todoService.findAll()).hasSize(1);
+        assertThat(todoService.findById(1L)).isNull();
+    }
 }


### PR DESCRIPTION
## 작업 내용
- To-Do 도메인 모델 정의
- 인메모리 레포지토리 구현
- 서비스 계층 비즈니스 로직 구현
- REST 컨트롤러 구현
- Swagger(OpenAPI) 설정
- TodoController 유닛 테스트 추가
- TodoService 유닛 테스트 추가
- 빈 목록 조회 시 204 응답 반환하도록 수정

## 관련 이슈
- close #9 

## 변경 사항
- [X] 기능 구현
- [ ] 설정/정책 변경
- [ ] 문서 수정

## 체크리스트
- [x] TodoController 유닛 테스트 통과
- [x] TodoService 유닛 테스트 통과
- [x] 로컬 서버 정상 실행
- [x] Swagger UI를 통한 API 호출 확인
